### PR TITLE
Add support for Python 3

### DIFF
--- a/QuickStart.rst
+++ b/QuickStart.rst
@@ -129,10 +129,9 @@ installing additional docutils__ module::
 
     pip install docutils
 
-Notice that at the time of this writing Python 3 is not yet officially
-supported. See the aforementioned `installation instructions`_ for information
-about an unofficial Python 3 port and the latest status of Python 3 support in
-general.
+Notice that Robot Framework 3.0 is the first Robot Framework version to support
+Python 3. See the aforementioned `installation instructions`_ for information
+about Python 2 vs Python 3.
 
 .. _`Robot Framework installation instructions`:
    https://github.com/robotframework/robotframework/blob/master/INSTALL.rst

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@ through it and look at the examples, but you can also use the guide as
 an executable demo.
 
 The guide itself is in `<QuickStart.rst>`_ file. It replaces the old version
-still available on the `old project pages`__.
+still available on the `old project pages`__. Robot Framework 3.0 introduced
+python 3 support. This guide executes under Python 2.7, 3.3, and newer.
 
 Copyright © Nokia Solutions and Networks. Licensed under the
 `Creative Commons Attribution 3.0 Unported`__ license.

--- a/lib/LoginLibrary.py
+++ b/lib/LoginLibrary.py
@@ -26,6 +26,6 @@ class LoginLibrary(object):
 
     def _run_command(self, command, *args):
         command = [sys.executable, self._sut_path, command] + list(args)
-        process = subprocess.Popen(command, stdout=subprocess.PIPE,
+        process = subprocess.Popen(command, universal_newlines=True, stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT)
         self._status = process.communicate()[0].strip()

--- a/sut/login.py
+++ b/sut/login.py
@@ -120,8 +120,8 @@ def change_password(username, old_pwd, new_pwd):
 
 
 def help():
-    print(('Usage: %s { create | login | change-password | help }'
-           % os.path.basename(sys.argv[0])))
+    print('Usage: %s { create | login | change-password | help }'
+           % os.path.basename(sys.argv[0]))
 
 
 if __name__ == '__main__':

--- a/sut/login.py
+++ b/sut/login.py
@@ -27,7 +27,7 @@ class UserDataBase(object):
     def create_user(self, username, password):
         try:
             user = User(username, password)
-        except ValueError, err:
+        except ValueError as err:
             return 'Creating user failed: %s' % err
         self.users[user.username] = user
         return 'SUCCESS'
@@ -47,14 +47,14 @@ class UserDataBase(object):
             if not self._is_valid_user(username, old_pwd):
                 raise ValueError('Access Denied')
             self.users[username].password = new_pwd
-        except ValueError, err:
+        except ValueError as err:
             return 'Changing password failed: %s' % err
         else:
             return 'SUCCESS'
 
     def save(self):
         with open(self.db_file, 'w') as file:
-            for user in self.users.values():
+            for user in list(self.users.values()):
                 file.write('%s\t%s\t%s\n'
                            % (user.username, user.password, user.status))
 
@@ -104,22 +104,22 @@ class User(object):
 
 def login(username, password):
     with UserDataBase() as db:
-        print db.login(username, password)
+        print(db.login(username, password))
 
 
 def create_user(username, password):
     with UserDataBase() as db:
-        print db.create_user(username, password)
+        print(db.create_user(username, password))
 
 
 def change_password(username, old_pwd, new_pwd):
     with UserDataBase() as db:
-        print db.change_password(username, old_pwd, new_pwd)
+        print(db.change_password(username, old_pwd, new_pwd))
 
 
 def help():
-    print ('Usage: %s { create | login | change-password | help }'
-           % os.path.basename(sys.argv[0]))
+    print(('Usage: %s { create | login | change-password | help }'
+           % os.path.basename(sys.argv[0])))
 
 
 if __name__ == '__main__':

--- a/sut/login.py
+++ b/sut/login.py
@@ -56,7 +56,7 @@ class UserDataBase(object):
 
     def save(self):
         with open(self.db_file, 'w') as file:
-            for user in list(self.users.values()):
+            for user in self.users.values():
                 file.write('%s\t%s\t%s\n'
                            % (user.username, user.password, user.status))
 

--- a/sut/login.py
+++ b/sut/login.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os.path
 import sys
 import tempfile


### PR DESCRIPTION
Minimal support for Python 3.

All tests pass with:

Robot Framework 3.0 (Python 2.7.5 on win32)
Robot Framework 3.0 (Python 3.4.3 on win32)

Note: I think the notice on Python 3 in QuickStart.rst should be updated if this pull request is accepted.
