### PR TITLE
BUILD.rst: Changes "git st" to "git status"

### DIFF
--- a/BUILD.rst
+++ b/BUILD.rst
@@ -3,7 +3,7 @@ Creating releases
 
 1. Check that master is up-to-date::
 
-    git st
+    git status
     git pull
     git push
 


### PR DESCRIPTION
Changes `git st` to `git status`.

`git st` isn't a standard command, although the original author may have an alias configured. Running `git st` on a standard Git setup gives:

```
$ git st
git: 'st' is not a git command. See 'git --help'.

The most similar commands are
	status
	reset
	stage
	stash
	svn
```